### PR TITLE
Improve performance of haskell parser

### DIFF
--- a/attoparsec/src/Main.hs
+++ b/attoparsec/src/Main.hs
@@ -14,29 +14,10 @@ data BOX = FTYP B.ByteString Word32 [B.ByteString] | FREE | MOOV | SKIP | MDAT 
 
 ftypBox :: C.Parser BOX
 ftypBox = do
-  C.string "ftyp"
   major_brand         <- C.take 4
   major_brand_version <- Bin.anyWord32be
   compatible_brands   <- C.many' (C.take 4)
   return $ FTYP major_brand major_brand_version compatible_brands
-
-freeBox = do
-  C.string "free"
-  return  FREE
-mdat = do
-  C.string "mdat"
-  return  MDAT
-moov = do
-  C.string "moov"
-  return  MOOV
-skip = do
-  C.string "skip"
-  return SKIP
-mdra = C.string "mdra"
-dref = C.string "dref"
-cmov = C.string "cmov"
-rmra = C.string "rmra"
-
 
 mp4Box :: C.Parser LV
 mp4Box = do
@@ -44,7 +25,15 @@ mp4Box = do
   Right value  <- C.parseOnly anyBox <$> C.take (length - 4)
   return $ LV length value
 
-anyBox = C.choice [ftypBox, freeBox, moov, skip, mdat]
+anyBox = do
+  name <- C.take 4
+  case name of
+    "ftyp" -> ftypBox
+    "free" -> return FREE
+    "mdat" -> return MDAT
+    "moov" -> return MOOV
+    "skip" -> return SKIP
+    _      -> fail "Unknown box type"
 
 mp4Parser = C.many1 mp4Box
 


### PR DESCRIPTION
The parser using attoparsec is using choice to parse the box type. This
basically reads 4 bytes and compares them against a string. If the
comparison fails, it has to go back and read 4 bytes again for the next
match. What can be done instead is first reading the box name and then
checking all box types. Because we do not have to rely on backtracking
we get noticeably better performance.
Before:

```
benchmarking IO/small
time                 1.662 μs   (1.661 μs .. 1.664 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.663 μs   (1.662 μs .. 1.666 μs)
std dev              5.140 ns   (1.455 ns .. 11.26 ns)

benchmarking IO/big buck bunny
time                 1.616 μs   (1.616 μs .. 1.616 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.617 μs   (1.616 μs .. 1.620 μs)
std dev              4.874 ns   (593.1 ps .. 10.34 ns)
```

After:

```
benchmarking IO/small
time                 1.322 μs   (1.321 μs .. 1.324 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.323 μs   (1.321 μs .. 1.332 μs)
std dev              12.23 ns   (898.6 ps .. 28.09 ns)

benchmarking IO/big buck bunny
time                 1.276 μs   (1.275 μs .. 1.277 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.276 μs   (1.275 μs .. 1.276 μs)
std dev              1.423 ns   (1.082 ns .. 1.945 ns)
```

I am not sure if the hammer and nom versions do backtracking. It is not really needed in this case. If they do, then the comparison is fair and I apologize for wasting your time.
