### PR TITLE
Improve strictness and efficiency of cereal benchmark

### DIFF
--- a/haskell-cereal/mp4.cabal
+++ b/haskell-cereal/mp4.cabal
@@ -20,7 +20,7 @@ executable mp4
   main-is:             Main.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       criterion, cereal, bytestring, base >=4.7 && <5
+  build-depends:       criterion, cereal, bytestring, vector, base >=4.7 && <5
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2


### PR DESCRIPTION
This benchmark makes two changes:
- It makes the data structures fully strict (so that weak-head-normal-form is equivalent to normal form)
- Replaces the uses of lists with vectors instead

This makes the comparison more accurate (the previous version was not fully materializing the list) and more efficient.  My version runs 10% faster on my machine.

Before:

``` haskell
benchmarking IO/small
time                 217.8 ns   (212.5 ns .. 225.3 ns)
                     0.995 R²   (0.993 R² .. 0.998 R²)
mean                 216.1 ns   (212.6 ns .. 220.9 ns)
std dev              13.63 ns   (10.91 ns .. 17.35 ns)
variance introduced by outliers: 78% (severely inflated)

benchmarking IO/big buck bunny
time                 230.1 ns   (222.2 ns .. 238.8 ns)
                     0.991 R²   (0.987 R² .. 0.996 R²)
mean                 220.2 ns   (214.6 ns .. 227.4 ns)
std dev              20.33 ns   (16.35 ns .. 25.75 ns)
variance introduced by outliers: 89% (severely inflated)

```

After:

``` haskell
benchmarking IO/small
time                 192.9 ns   (191.2 ns .. 194.7 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 192.0 ns   (189.7 ns .. 194.1 ns)
std dev              7.167 ns   (6.017 ns .. 8.685 ns)
variance introduced by outliers: 56% (severely inflated)

benchmarking IO/big buck bunny
time                 196.9 ns   (194.2 ns .. 199.9 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 196.4 ns   (193.5 ns .. 200.1 ns)
std dev              10.86 ns   (8.569 ns .. 15.97 ns)
variance introduced by outliers: 74% (severely inflated)

```
