### PR TITLE
Avoid warning for unused `test::Bencher`

### DIFF
--- a/mp4/src/main.rs
+++ b/mp4/src/main.rs
@@ -110,6 +110,7 @@ fn data_interpreter(bytes:&[u8]) -> IResult<&[u8], MP4Box> {
 
 named!(full_data_interpreter(&[u8]) -> Vec<MP4Box>, many0!(data_interpreter));
 
+#[cfg(test)]
 use test::Bencher;
 #[bench]
 fn small_test(b: &mut Bencher) {


### PR DESCRIPTION
When running `cargo build` rustc produces the warning:

```
src/main.rs:113:5: 113:18 warning: unused import, #[warn(unused_imports)] on by default
src/main.rs:113 use test::Bencher;
```

This is because functions marked with `#[bench]` are not compiled
during a non-test / non-bench build, leaving `test::Bencher` unused in
such a build.

In this commit we conditionally compile the include of `test::Bencher`
only when performing a test build (which are used for benchmarking).
