### PR TITLE
GHC 8.0.2, stack, lower/upper bounds

### DIFF
--- a/http/attoparsec/http.cabal
+++ b/http/attoparsec/http.cabal
@@ -20,7 +20,11 @@ executable http
   main-is:             Main.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       criterion, attoparsec-binary, bytestring, attoparsec, base
+  build-depends:       base >=4.7 && <4.10,
+                       attoparsec >=0.13 && <0.14,
+                       attoparsec-binary >=0.2 && <0.3,
+                       bytestring >=0.10 && <0.11,
+                       criterion >=1.1 && <1.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   --ghc-options:         -O2 -fllvm -pgmlo opt-3.4 -pgmlc llc-3.4

--- a/http/attoparsec/stack.yaml
+++ b/http/attoparsec/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-8.2
+
+packages:
+- '.'
+
+extra-deps: []
+
+flags: {}
+
+extra-package-dbs: []

--- a/mp4/attoparsec/mp4.cabal
+++ b/mp4/attoparsec/mp4.cabal
@@ -20,7 +20,13 @@ executable mp4
   main-is:             Main.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       criterion, attoparsec-binary, bytestring, attoparsec, vector, deepseq, base >=4.7 && <4.8
+  build-depends:       base >=4.7 && <4.10,
+                       attoparsec >=0.13 && <0.14,
+                       attoparsec-binary >=0.2 && <0.3,
+                       bytestring >=0.10 && <0.11,
+                       criterion >=1.1 && <1.2,
+                       deepseq >=1.4 && <1.5,
+                       vector >=0.11 && <0.13
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2 -fllvm -pgmlo opt-3.4 -pgmlc llc-3.4

--- a/mp4/attoparsec/stack.yaml
+++ b/mp4/attoparsec/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-8.2
+
+packages:
+  - '.'
+
+extra-deps: []
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
I removed llvm support in the `mp4/attoparsec` sample because I cannot use it. Should you think it’s important, you’d wait a bit to merge the PR? :D

I’ll test with `llvm-3.7` tonight and see what to do with that.