### PR TITLE
feat(combine) Update Combine to 3.0.0

### DIFF
--- a/http/combine-http/Cargo.toml
+++ b/http/combine-http/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 
 [dependencies]
-combine = "3.0.0-beta.1"
+combine = "3.0.0"
 bencher = "0.1"

--- a/http/combine-http/src/main.rs
+++ b/http/combine-http/src/main.rs
@@ -5,11 +5,8 @@ extern crate combine;
 
 use bencher::{black_box, Bencher};
 
-use std::fmt;
-
 use combine::{many, token, ParseError, Parser, RangeStream, many1};
 use combine::range::{range, take_while1};
-use combine::stream::easy;
 
 #[derive(Debug)]
 struct Request<'a> {


### PR DESCRIPTION
The results on my machine are:

```
test bigger_test ... bench:     383,678 ns/iter (+/- 59,868) = 278 MB/s
test one_test    ... bench:       1,120 ns/iter (+/- 658) = 259 MB/s
test small_test  ... bench:      74,610 ns/iter (+/- 38,222) = 286 MB/s
```