### PR TITLE
Improve/fix combine benches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target
 Cargo.lock
 **/dist
 **/.cabal-sandbox

--- a/http/combine-http/Cargo.toml
+++ b/http/combine-http/Cargo.toml
@@ -6,3 +6,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 [dependencies]
 combine = "^3.0.0"
 bencher = "0.1"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/http/nom-http/Cargo.toml
+++ b/http/nom-http/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 nom = {git = "https://github.com/Geal/nom" }
 bencher = "0.1"
 
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/http/nom-optimized/Cargo.toml
+++ b/http/nom-optimized/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 nom = {git = "https://github.com/Geal/nom" }
 bencher = "0.1"
 stdsimd = "0.0.4"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/json/combine/Cargo.toml
+++ b/json/combine/Cargo.toml
@@ -6,3 +6,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 [dependencies]
 combine = "3.0.0"
 bencher = "0.1"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/json/combine/src/main.rs
+++ b/json/combine/src/main.rs
@@ -7,35 +7,31 @@ extern crate bencher;
 extern crate combine;
 
 use std::collections::HashMap;
-use std::io::Read;
-use std::fs::File;
-use std::path::Path;
-
+use std::hash::Hash;
 use bencher::{black_box, Bencher};
 
-use combine::stream::buffered::BufferedStream;
-use combine::{Parser, Stream, StreamOnce};
+use combine::{Parser, RangeStream, Stream, StreamOnce};
 use combine::error::{Consumed, ParseError};
 
 use combine::parser::char::{char, digit, spaces, string};
-use combine::parser::item::{any, satisfy, satisfy_map};
+use combine::parser::item::{any, one_of, satisfy_map};
 use combine::parser::sequence::between;
-use combine::parser::repeat::{many, sep_by, many1};
+use combine::parser::repeat::{sep_by, skip_many, skip_many1};
 use combine::parser::choice::{choice, optional};
 use combine::parser::function::parser;
+use combine::parser::range;
 
-use combine::stream::IteratorStream;
-use combine::stream::state::{SourcePosition, State};
-
-//FIXME: return a &str instead of a string for String element and object keys
 #[derive(PartialEq, Debug)]
-enum Value {
+enum Value<S>
+where
+    S: Eq + Hash,
+{
     Number(f64),
-    String(String),
+    String(S),
     Bool(bool),
     Null,
-    Object(HashMap<String, Value>),
-    Array(Vec<Value>),
+    Object(HashMap<S, Value<S>>),
+    Array(Vec<Value<S>>),
 }
 
 fn lex<P>(p: P) -> impl Parser<Input = P::Input, Output = P::Output>
@@ -51,53 +47,23 @@ where
     p.skip(spaces())
 }
 
-fn integer<I>() -> impl Parser<Input = I, Output = i64>
+fn number<'a, I>() -> impl Parser<Input = I, Output = f64>
 where
-    I: Stream<Item = char>,
+    I: RangeStream<Item = char, Range = &'a str>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    lex(many1(digit()))
-        .map(|s: String| {
-            let mut n = 0;
-            for c in s.chars() {
-                n = n * 10 + (c as i64 - '0' as i64);
-            }
-            n
-        })
-        .expected("integer")
-}
-
-fn number<I>() -> impl Parser<Input = I, Output = f64>
-where
-    I: Stream<Item = char>,
-    I::Error: ParseError<I::Item, I::Range, I::Position>,
-{
-    let i = char('0').map(|_| 0.0).or(integer().map(|x| x as f64));
-    let fractional = many(digit()).map(|digits: String| {
-        let mut magnitude = 1.0;
-        digits.chars().fold(0.0, |acc, d| {
-            magnitude /= 10.0;
-            match d.to_digit(10) {
-                Some(d) => acc + (d as f64) * magnitude,
-                None => panic!("Not a digit"),
-            }
-        })
-    });
-
-    let exp = satisfy(|c| c == 'e' || c == 'E').with(optional(char('-')).and(integer()));
-    lex(optional(char('-'))
-        .and(i)
-        .map(|(sign, n)| if sign.is_some() { -n } else { n })
-        .and(optional(char('.')).with(fractional))
-        .map(|(x, y)| if x >= 0.0 { x + y } else { x - y })
-        .and(optional(exp))
-        .map(|(n, exp_option)| match exp_option {
-            Some((sign, e)) => {
-                let e = if sign.is_some() { -e } else { e };
-                n * 10.0f64.powi(e as i32)
-            }
-            None => n,
-        })).expected("number")
+    lex(range::recognize((
+        optional(char('-')),
+        char('0').or((
+            skip_many1(digit()),
+            optional((char('.'), skip_many(digit()))),
+        ).map(|_| '0')),
+        optional((
+            (one_of("eE".chars()), optional(one_of("+-".chars()))),
+            skip_many1(digit()),
+        )),
+    ))).map(|s: &'a str| s.parse().unwrap())
+        .expected("number")
 }
 
 fn json_char<I>() -> impl Parser<Input = I, Output = char>
@@ -128,30 +94,44 @@ where
     })
 }
 
-fn json_string<I>() -> impl Parser<Input = I, Output = String>
+fn json_string<'a, I>() -> impl Parser<Input = I, Output = &'a str>
 where
-    I: Stream<Item = char>,
+    I: RangeStream<Item = char, Range = &'a str>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    between(char('"'), lex(char('"')), many(json_char())).expected("string")
+    between(
+        char('"'),
+        lex(char('"')),
+        range::recognize(skip_many(json_char())),
+    ).expected("string")
 }
 
-fn object<I>() -> impl Parser<Input = I, Output = Value>
+fn object<'a, I>() -> impl Parser<Input = I, Output = HashMap<&'a str, Value<&'a str>>>
 where
-    I: Stream<Item = char>,
+    I: RangeStream<Item = char, Range = &'a str>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     let field = (json_string(), lex(char(':')), json_value_()).map(|t| (t.0, t.2));
     let fields = sep_by(field, lex(char(',')));
-    between(lex(char('{')), lex(char('}')), fields)
-        .map(Value::Object)
-        .expected("object")
+    between(lex(char('{')), lex(char('}')), fields).expected("object")
+}
+
+fn array<'a, I>() -> impl Parser<Input = I, Output = Vec<Value<&'a str>>>
+where
+    I: RangeStream<Item = char, Range = &'a str>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    between(
+        lex(char('[')),
+        lex(char(']')),
+        sep_by(json_value_(), lex(char(','))),
+    ).expected("array")
 }
 
 #[inline(always)]
-fn json_value<I>() -> impl Parser<Input = I, Output = Value>
+fn json_value<'a, I>() -> impl Parser<Input = I, Output = Value<&'a str>>
 where
-    I: Stream<Item = char>,
+    I: RangeStream<Item = char, Range = &'a str>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     spaces().with(json_value_())
@@ -161,19 +141,13 @@ where
 // from containing itself
 parser!{
     #[inline(always)]
-    fn json_value_[I]()(I) -> Value
-        where [ I: Stream<Item = char> ]
+    fn json_value_['a, I]()(I) -> Value<I::Range>
+        where [ I: RangeStream<Item = char, Range = &'a str> ]
     {
-        let array = between(
-            lex(char('[')),
-            lex(char(']')),
-            sep_by(json_value_(), lex(char(','))),
-        ).map(Value::Array);
-
         choice((
             json_string().map(Value::String),
-            object(),
-            array,
+            object().map(Value::Object),
+            array().map(Value::Array),
             number().map(Value::Number),
             lex(string("false").map(|_| Value::Bool(false))),
             lex(string("true").map(|_| Value::Bool(true))),
@@ -226,9 +200,9 @@ fn json_test() {
 fn parse(b: &mut Bencher, buffer: &str) {
     let mut parser = json_value();
     b.iter(|| {
-        let mut buf = black_box(buffer);
+        let buf = black_box(buffer);
 
-        let result = parser.easy_parse(State::new(buf)).unwrap();
+        let result = parser.easy_parse(buf).unwrap();
         black_box(result)
     });
 }
@@ -266,7 +240,7 @@ fn test() {
     //let data = include_str!("../../test.json");
 
     let mut parser = json_value();
-    println!("test: {:?}", parser.parse(State::new(data)).unwrap());
+    println!("test: {:?}", parser.parse(data).unwrap());
     panic!()
 }
 

--- a/json/nom/Cargo.toml
+++ b/json/nom/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 nom = { git = "https://github.com/geal/nom" }
 #nom = {path = "/Users/geal/dev/rust/projects/nom" }
 bencher = "0.1"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/json/pest/Cargo.toml
+++ b/json/pest/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 pest = "^1.0.0"
 pest_grammars = "^1.0.0"
 bencher = "0.1"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
https://github.com/Geal/parser_benchmarks/commit/207c8b09d2a9441c38ddc4801992c8b16528b979

Enable full lto and codegen-units=1 for all rust parsers

In combine's case this speeds up the parser quite significantly
since LLVM will otherwise fail to inline a lot of parsers. nom is less
affected since all parsers are implicitly inlined due to using macros

```
 name                   old ns/iter         new ns/iter         diff ns/iter   diff %  speedup
 bigger_test            684,954 (156 MB/s)  583,877 (183 MB/s)      -101,077  -14.76%   x 1.17
 httparse_example_test  2,970 (236 MB/s)    2,302 (305 MB/s)            -668  -22.49%   x 1.29
 one_test               2,066 (140 MB/s)    1,695 (171 MB/s)            -371  -17.96%   x 1.22
 small_test             154,901 (138 MB/s)  120,635 (177 MB/s)       -34,266  -22.12%   x 1.28
```