### PR TITLE
Add benchmark against Serde + serde_json

### DIFF
--- a/json/serde/Cargo.toml
+++ b/json/serde/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bench-serde-json"
+version = "0.0.0"
+authors = ["David Tolnay <dtolnay@gmail.com>"]
+publish = false
+
+[dependencies]
+bencher = "0.1"
+serde = "1.0"
+serde_json = "1.0"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/json/serde/src/main.rs
+++ b/json/serde/src/main.rs
@@ -1,0 +1,125 @@
+#[macro_use]
+extern crate bencher;
+
+extern crate serde;
+extern crate serde_json;
+
+use bencher::{black_box, Bencher};
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+
+#[derive(Debug, PartialEq)]
+pub enum Value<'a> {
+    Str(Cow<'a, str>),
+    Num(f64),
+    Boolean(bool),
+    Array(Vec<Value<'a>>),
+    Object(HashMap<&'a str, Value<'a>>),
+}
+
+impl<'de: 'a, 'a> Deserialize<'de> for Value<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value<'de>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("any JSON value")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(Value::Str(Cow::Owned(v.to_owned())))
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E> {
+                Ok(Value::Str(Cow::Borrowed(v)))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(Value::Num(v as f64))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(Value::Num(v as f64))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(Value::Num(v))
+            }
+
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(Value::Boolean(v))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut array = Vec::new();
+                while let Some(value) = seq.next_element()? {
+                    array.push(value);
+                }
+                Ok(Value::Array(array))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut object = HashMap::new();
+                while let Some((key, value)) = map.next_entry()? {
+                    object.insert(key, value);
+                }
+                Ok(Value::Object(object))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+fn basic(b: &mut Bencher) {
+    let data = "  { \"a\"\t: 42,
+  \"b\": [ \"x\", \"y\", 12 ] ,
+  \"c\": { \"hello\" : \"world\"
+  }
+  }  ";
+
+    b.bytes = data.len() as u64;
+    parse(b, data)
+}
+
+fn data(b: &mut Bencher) {
+    let data = include_str!("../../data.json");
+    b.bytes = data.len() as u64;
+    parse(b, data)
+}
+
+fn canada(b: &mut Bencher) {
+    let data = include_str!("../../canada.json");
+    b.bytes = data.len() as u64;
+    parse(b, data)
+}
+
+fn apache(b: &mut Bencher) {
+    let data = include_str!("../../apache_builds.json");
+    b.bytes = data.len() as u64;
+    parse(b, data)
+}
+
+fn parse(b: &mut Bencher, buffer: &str) {
+    b.iter(|| {
+        serde_json::from_str::<Value>(black_box(buffer)).unwrap()
+    });
+}
+
+benchmark_group!(json, basic, data, apache, canada);
+benchmark_main!(json);


### PR DESCRIPTION
@Geal I'll leave it to you to update the table in README.md on your machine, but here is what I get:

|         | basic                             | canada.json |apache_builds.json | data.json |
| ------- | --------------------------------- | ----------- | ----------------- | --------- |
| nom     | 1,072 ns/iter (+/- 150) = 70 MB/s | 38,551,532 ns/iter (+/- 1,859,224) = 58 MB/s | 849,338 ns/iter (+/- 57,980) = 149 MB/s | 48,957 ns/iter (+/- 2,315) = 188 MB/s |
| pest    | 1,406 ns/iter (+/- 80) = 54 MB/s | 21,370,463 ns/iter (+/- 931,725) = 105 MB/s | 1,939,657 ns/iter (+/- 119,420) = 65 MB/s | 148,711 ns/iter (+/- 4,947) = 62 MB/s |
| serde   | **666 ns/iter (+/- 16) = 114 MB/s** | **14,136,997 ns/iter (+/- 1,109,969) = 159 MB/s** | **527,243 ns/iter (+/- 16,598) = 241 MB/s** | **28,053 ns/iter (+/- 1,583) = 329 MB/s** |
