### PR TITLE
Switch hasher to fnv

### DIFF
--- a/json/combine/Cargo.toml
+++ b/json/combine/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 [dependencies]
 combine = "3.3.0"
 bencher = "0.1"
+fnv = "1.0"
 
 [profile.release]
 lto = "fat"

--- a/json/combine/src/main.rs
+++ b/json/combine/src/main.rs
@@ -4,8 +4,10 @@ extern crate bencher;
 #[macro_use]
 extern crate combine;
 
+extern crate fnv;
+
 use bencher::{black_box, Bencher};
-use std::collections::HashMap;
+use fnv::FnvHashMap as HashMap;
 use std::hash::Hash;
 use std::str;
 
@@ -169,7 +171,7 @@ fn json_test() {
     let expected = Object(
         vec![
             ("array", Array(vec![Number(1.0), String("".to_string())])),
-            ("object", Object(HashMap::new())),
+            ("object", Object(HashMap::default())),
             ("number", Number(3.14)),
             ("small_number", Number(0.59)),
             ("int", Number(-100.)),

--- a/json/nom/Cargo.toml
+++ b/json/nom/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 nom = "^4.0"
 #nom = {path = "/Users/geal/dev/rust/projects/nom" }
 bencher = "0.1"
+fnv = "1.0"
 
 [profile.release]
 lto = "fat"

--- a/json/nom/src/main.rs
+++ b/json/nom/src/main.rs
@@ -3,11 +3,13 @@ extern crate bencher;
 #[macro_use]
 extern crate nom;
 
+extern crate fnv;
+
 use bencher::{black_box, Bencher};
+use fnv::FnvHashMap as HashMap;
 use nom::{HexDisplay, alphanumeric, recognize_float, sp};
 
 use std::str;
-use std::collections::HashMap;
 
 pub fn is_string_character(c: u8) -> bool {
   //FIXME: should validate unicode character

--- a/json/peg/Cargo.toml
+++ b/json/peg/Cargo.toml
@@ -9,6 +9,7 @@ peg = "0.5.4"
 
 [dependencies]
 bencher = "0.1"
+fnv = "1.0"
 
 [profile]
 

--- a/json/peg/src/json.rustpeg
+++ b/json/peg/src/json.rustpeg
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
 use std::str::FromStr;
+
+use fnv::FnvHashMap as HashMap;
 
 use super::JsonValue;
 
@@ -26,7 +27,7 @@ key_value -> (&'input str, JsonValue<'input>)
 
 hash -> JsonValue<'input>
   = ws "{" ws pairs:(key_value ** comma) ws "}" ws {
-    let mut map: HashMap<&'input str, JsonValue<'input>> = HashMap::with_capacity(pairs.len());
+    let mut map = HashMap::<&str, JsonValue>::with_capacity_and_hasher(pairs.len(), Default::default());
     for (key, value) in pairs {
       map.insert(key, value);
     }

--- a/json/peg/src/main.rs
+++ b/json/peg/src/main.rs
@@ -1,9 +1,10 @@
 #[macro_use]
 extern crate bencher;
 
-use bencher::{black_box, Bencher};
+extern crate fnv;
 
-use std::collections::HashMap;
+use fnv::FnvHashMap as HashMap;
+use bencher::{black_box, Bencher};
 
 mod peg_json {
     include!(concat!(env!("OUT_DIR"), "/json.rs"));

--- a/json/pest/Cargo.toml
+++ b/json/pest/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
 pest = "^1.0.0"
 pest_grammars = "^1.0.0"
 bencher = "0.1"
+fnv = "1.0"
 
 [profile.release]
 lto = "fat"

--- a/json/pest/src/main.rs
+++ b/json/pest/src/main.rs
@@ -4,6 +4,8 @@ extern crate pest_grammars;
 #[macro_use]
 extern crate bencher;
 
+extern crate fnv;
+
 use bencher::{black_box, Bencher};
 
 use pest::Parser;
@@ -12,7 +14,7 @@ use pest::iterators::Pair;
 
 use pest_grammars::json::*;
 
-use std::collections::HashMap;
+use fnv::FnvHashMap as HashMap;
 
 enum Json<'i> {
     Null,

--- a/json/serde/Cargo.toml
+++ b/json/serde/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 bencher = "0.1"
+fnv = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 

--- a/json/serde/src/main.rs
+++ b/json/serde/src/main.rs
@@ -1,15 +1,15 @@
 #[macro_use]
 extern crate bencher;
 
+extern crate fnv;
 extern crate serde;
 extern crate serde_json;
 
-use bencher::{black_box, Bencher};
-
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fmt;
 
+use bencher::{black_box, Bencher};
+use fnv::FnvHashMap as HashMap;
 use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 
 #[derive(Debug, PartialEq)]
@@ -74,7 +74,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for Value<'a> {
             where
                 A: MapAccess<'de>,
             {
-                let mut object = HashMap::new();
+                let mut object = HashMap::default();
                 while let Some((key, value)) = map.next_entry()? {
                     object.insert(key, value);
                 }


### PR DESCRIPTION
More than 40% of the time in some runs was spent hashing. That time is noise in the benchmark. This commit replaces the default HashMap hasher with a faster hash function to focus more of the benchmark time on parsing, which is what we are trying to compare.

Fixes #21.