### PR TITLE
Add pom JSON benchmarks

### DIFF
--- a/json/pom-char/Cargo.toml
+++ b/json/pom-char/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pom-json"
+version = "0.1.0"
+authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
+
+[dependencies]
+bencher = "0.1"
+fnv = "1.0"
+jemallocator = "0.1.8"
+pom = "3.0.2"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+debug = true

--- a/json/pom-char/src/main.rs
+++ b/json/pom-char/src/main.rs
@@ -1,0 +1,148 @@
+#[macro_use]
+extern crate bencher;
+
+extern crate fnv;
+extern crate jemallocator;
+extern crate pom;
+
+use std::char::{self, REPLACEMENT_CHARACTER};
+use std::iter::FromIterator;
+use std::str::{self, FromStr};
+
+use bencher::{black_box, Bencher};
+use fnv::FnvHashMap as HashMap;
+use pom::parser::*;
+
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[derive(Debug, PartialEq)]
+pub enum JsonValue {
+    Null,
+    Bool(bool),
+    Str(String),
+    Num(f64),
+    Array(Vec<JsonValue>),
+    Object(HashMap<String, JsonValue>),
+}
+
+fn space<'a>() -> Parser<'a, char, ()> {
+    one_of(" \t\r\n").repeat(0..).discard()
+}
+
+fn number<'a>() -> Parser<'a, char, f64> {
+    let integer = one_of("123456789") - one_of("0123456789").repeat(0..) | sym('0');
+    let frac = sym('.') + one_of("0123456789").repeat(1..);
+    let exp = one_of("eE") + one_of("+-").opt() + one_of("0123456789").repeat(1..);
+    let number = sym('-').opt() + integer + frac.opt() + exp.opt();
+    number
+        .collect()
+        .map(String::from_iter)
+        .convert(|s| f64::from_str(&s))
+}
+
+fn string<'a>() -> Parser<'a, char, String> {
+    let special_char = one_of("\\/\"")
+        | sym('b').map(|_| '\x08')
+        | sym('f').map(|_| '\x0C')
+        | sym('n').map(|_| '\n')
+        | sym('r').map(|_| '\r')
+        | sym('t').map(|_| '\t');
+    let escape_sequence = sym('\\') * special_char;
+    let char_string = (none_of("\\\"") | escape_sequence)
+        .repeat(1..)
+        .map(String::from_iter);
+    let utf16_char = tag("\\u")
+        * is_a(|c: char| c.is_digit(16))
+            .repeat(4)
+            .map(String::from_iter)
+            .convert(|digits| u16::from_str_radix(&digits, 16));
+    let utf16_string = utf16_char.repeat(1..).map(|chars| {
+        char::decode_utf16(chars)
+            .map(|r| r.unwrap_or(REPLACEMENT_CHARACTER))
+            .collect::<String>()
+    });
+    let string = sym('"') * (char_string | utf16_string).repeat(0..) - sym('"');
+    string.map(|strings| strings.concat())
+}
+
+fn array<'a>() -> Parser<'a, char, Vec<JsonValue>> {
+    let elems = list(call(value), sym(',') * space());
+    sym('[') * space() * elems - sym(']')
+}
+
+fn object<'a>() -> Parser<'a, char, HashMap<String, JsonValue>> {
+    let member = string() - space() - sym(':') - space() + call(value);
+    let members = list(member, sym(',') * space());
+    let obj = sym('{') * space() * members - sym('}');
+    obj.map(|members| members.into_iter().collect())
+}
+
+fn value<'a>() -> Parser<'a, char, JsonValue> {
+    (tag("null").map(|_| JsonValue::Null)
+        | tag("true").map(|_| JsonValue::Bool(true))
+        | tag("false").map(|_| JsonValue::Bool(false))
+        | number().map(|num| JsonValue::Num(num))
+        | string().map(|text| JsonValue::Str(text))
+        | array().map(|arr| JsonValue::Array(arr))
+        | object().map(|obj| JsonValue::Object(obj)))
+        - space()
+}
+
+pub fn root<'a>() -> Parser<'a, char, JsonValue> {
+    space() * value() - end()
+}
+
+#[test]
+fn test() {
+    let data = include_str!("../../test.json");
+    let chars: Vec<_> = data.chars().collect();
+    println!("test: {:?}", root().parse(&chars).unwrap());
+    panic!()
+}
+
+fn basic(b: &mut Bencher) {
+    let data = "  { \"a\"\t: 42,
+  \"b\": [ \"x\", \"y\", 12 ] ,
+  \"c\": { \"hello\" : \"world\"
+  }
+  }  ";
+
+    let chars: Vec<_> = data.chars().collect();
+    b.bytes = chars.len() as u64;
+    parse(b, &chars)
+}
+
+fn data(b: &mut Bencher) {
+    let data = include_str!("../../data.json");
+    let chars: Vec<_> = data.chars().collect();
+    b.bytes = chars.len() as u64;
+    parse(b, &chars)
+}
+
+fn canada(b: &mut Bencher) {
+    let data = include_str!("../../canada.json");
+    let chars: Vec<_> = data.chars().collect();
+    b.bytes = chars.len() as u64;
+    parse(b, &chars)
+}
+
+fn apache(b: &mut Bencher) {
+    let data = include_str!("../../apache_builds.json");
+    let chars: Vec<_> = data.chars().collect();
+    b.bytes = chars.len() as u64;
+    parse(b, &chars)
+}
+
+fn parse<'a>(b: &mut Bencher, buffer: &'a [char]) {
+    b.iter(|| {
+        let buf = black_box(buffer);
+        match root().parse(buf) {
+            Ok(out) => return out,
+            Err(err) => panic!("got err: {:?}", err),
+        }
+    });
+}
+
+benchmark_group!(json, basic, data, apache, canada);
+benchmark_main!(json);

--- a/json/pom/Cargo.toml
+++ b/json/pom/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pom-json"
+version = "0.1.0"
+authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
+
+[dependencies]
+bencher = "0.1"
+fnv = "1.0"
+jemallocator = "0.1.8"
+pom = "3.0.2"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+debug = true

--- a/json/pom/src/main.rs
+++ b/json/pom/src/main.rs
@@ -1,0 +1,143 @@
+#[macro_use]
+extern crate bencher;
+
+extern crate fnv;
+extern crate jemallocator;
+extern crate pom;
+
+use std::char::{self, REPLACEMENT_CHARACTER};
+use std::str::{self, FromStr};
+
+use bencher::{black_box, Bencher};
+use fnv::FnvHashMap as HashMap;
+use pom::char_class::{digit, hex_digit, multispace};
+use pom::parser::*;
+
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[derive(Debug, PartialEq)]
+pub enum JsonValue {
+    Null,
+    Bool(bool),
+    Str(String),
+    Num(f64),
+    Array(Vec<JsonValue>),
+    Object(HashMap<String, JsonValue>),
+}
+
+fn space<'a>() -> Parser<'a, u8, ()> {
+    is_a(multispace).repeat(0..).discard()
+}
+
+fn number<'a>() -> Parser<'a, u8, f64> {
+    let integer = one_of(b"123456789") - is_a(digit).repeat(0..) | sym(b'0');
+    let frac = sym(b'.') + is_a(digit).repeat(1..);
+    let exp = one_of(b"eE") + one_of(b"+-").opt() + is_a(digit).repeat(1..);
+    let number = sym(b'-').opt() + integer + frac.opt() + exp.opt();
+    number
+        .collect()
+        .convert(str::from_utf8)
+        .convert(f64::from_str)
+}
+
+fn string<'a>() -> Parser<'a, u8, String> {
+    let special_char = one_of(b"\\/\"")
+        | sym(b'b').map(|_| b'\x08')
+        | sym(b'f').map(|_| b'\x0C')
+        | sym(b'n').map(|_| b'\n')
+        | sym(b'r').map(|_| b'\r')
+        | sym(b't').map(|_| b'\t');
+    let escape_sequence = sym(b'\\') * special_char;
+    let char_string = (none_of(b"\\\"") | escape_sequence)
+        .repeat(1..)
+        .convert(String::from_utf8);
+    let utf16_char = seq(b"\\u")
+        * is_a(hex_digit)
+            .repeat(4)
+            .convert(String::from_utf8)
+            .convert(|digits| u16::from_str_radix(&digits, 16));
+    let utf16_string = utf16_char.repeat(1..).map(|chars| {
+        char::decode_utf16(chars)
+            .map(|r| r.unwrap_or(REPLACEMENT_CHARACTER))
+            .collect::<String>()
+    });
+    let string = sym(b'"') * (char_string | utf16_string).repeat(0..) - sym(b'"');
+    string.map(|strings| strings.concat())
+}
+
+fn array<'a>() -> Parser<'a, u8, Vec<JsonValue>> {
+    let elems = list(call(value), sym(b',') * space());
+    sym(b'[') * space() * elems - sym(b']')
+}
+
+fn object<'a>() -> Parser<'a, u8, HashMap<String, JsonValue>> {
+    let member = string() - space() - sym(b':') - space() + call(value);
+    let members = list(member, sym(b',') * space());
+    let obj = sym(b'{') * space() * members - sym(b'}');
+    obj.map(|members| members.into_iter().collect())
+}
+
+fn value<'a>() -> Parser<'a, u8, JsonValue> {
+    (seq(b"null").map(|_| JsonValue::Null)
+        | seq(b"true").map(|_| JsonValue::Bool(true))
+        | seq(b"false").map(|_| JsonValue::Bool(false))
+        | number().map(|num| JsonValue::Num(num))
+        | string().map(|text| JsonValue::Str(text))
+        | array().map(|arr| JsonValue::Array(arr))
+        | object().map(|obj| JsonValue::Object(obj)))
+        - space()
+}
+
+pub fn root<'a>() -> Parser<'a, u8, JsonValue> {
+    space() * value() - end()
+}
+
+#[test]
+fn test() {
+    let data = include_bytes!("../../test.json");
+    println!("test: {:?}", root().parse(data).unwrap());
+    panic!()
+}
+
+fn basic(b: &mut Bencher) {
+    let data = b"  { \"a\"\t: 42,
+  \"b\": [ \"x\", \"y\", 12 ] ,
+  \"c\": { \"hello\" : \"world\"
+  }
+  }  ";
+
+    b.bytes = data.len() as u64;
+    parse(b, &data[..])
+}
+
+fn data(b: &mut Bencher) {
+    let data = include_bytes!("../../data.json");
+    b.bytes = data.len() as u64;
+    parse(b, data)
+}
+
+fn canada(b: &mut Bencher) {
+    let data = include_bytes!("../../canada.json");
+    b.bytes = data.len() as u64;
+    parse(b, data)
+}
+
+fn apache(b: &mut Bencher) {
+    let data = include_bytes!("../../apache_builds.json");
+    b.bytes = data.len() as u64;
+    parse(b, data)
+}
+
+fn parse<'a>(b: &mut Bencher, buffer: &'a [u8]) {
+    b.iter(|| {
+        let buf = black_box(buffer);
+        match root().parse(buf) {
+            Ok(out) => return out,
+            Err(err) => panic!("got err: {:?}", err),
+        }
+    });
+}
+
+benchmark_group!(json, basic, data, apache, canada);
+benchmark_main!(json);


### PR DESCRIPTION
### Added

* Create pom JSON (`u8`) benchmark based on the upstream [example](https://github.com/J-F-Liu/pom/blob/32b8db03ca61977ae1c1008e9e96c784294744aa/examples/json.rs).
* Create pom JSON (`char`) benchmark based on the upstream [example](https://github.com/J-F-Liu/pom/blob/32b8db03ca61977ae1c1008e9e96c784294744aa/examples/json_char.rs).

Both of these parsers should correctly handle UTF-8 escaping and replacement characters (it appears that some of the others in this repo do not). I'm willing to write pom equivalents for the other benchmarks in a separate pull request, if you would like!

Partially resolves #26.