### PR TITLE
Optimize attoparsec http parser

### DIFF
--- a/http/attoparsec/.gitignore
+++ b/http/attoparsec/.gitignore
@@ -1,1 +1,3 @@
 .stack-work
+dist-newstyle
+tags


### PR DESCRIPTION
Speed-up x1.5:
- small: 40μs to 26μs
- bigger: 228μs to 160μs